### PR TITLE
Use Dropwizard 1.x; specify US-ASCII in GTG response.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ eff-pom.xml
 /.settings
 /.classpath
 /.project
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -10,15 +10,15 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <dropwizard.version>0.8.1</dropwizard.version>
+        <dropwizard.version>1.1.3</dropwizard.version>
         <hamcrest.version>1.3</hamcrest.version>
         <java.version>1.8</java.version>
         <junit.version>4.11</junit.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-release-plugin.version>2.5</maven-release-plugin.version>
         <maven-resources-plugin.version>2.6</maven-resources-plugin.version>
-        <metrics.version>3.1.0</metrics.version>
-        <mockito.version>1.9.5</mockito.version>
+        <metrics.version>3.2.2</metrics.version>
+        <mockito.version>1.10.19</mockito.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/com/ft/platform/dropwizard/AdvancedHealthCheck.java
+++ b/src/main/java/com/ft/platform/dropwizard/AdvancedHealthCheck.java
@@ -1,7 +1,7 @@
 package com.ft.platform.dropwizard;
 
 import com.codahale.metrics.health.HealthCheck;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 public abstract class AdvancedHealthCheck extends HealthCheck implements Comparable<AdvancedHealthCheck> {
 
@@ -50,7 +50,7 @@ public abstract class AdvancedHealthCheck extends HealthCheck implements Compara
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this.getClass())
+        return MoreObjects.toStringHelper(this.getClass())
                 .add("id", id())
                 .add("name", name)
                 .add("severity", severity())

--- a/src/main/java/com/ft/platform/dropwizard/AdvancedResult.java
+++ b/src/main/java/com/ft/platform/dropwizard/AdvancedResult.java
@@ -3,7 +3,7 @@ package com.ft.platform.dropwizard;
 import com.codahale.metrics.health.HealthCheck;
 import com.ft.platform.dropwizard.system.Clock;
 import com.google.common.base.Joiner;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableMap;
 
 import java.io.ByteArrayOutputStream;
@@ -101,7 +101,7 @@ public class AdvancedResult {
 
 	@Override
 	public String toString() {
-		return Objects.toStringHelper(this.getClass())
+		return MoreObjects.toStringHelper(this.getClass())
 				.add("status", status)
 				.add("checkOutput", checkOutput)
 				.add("checkedDate", checkedDate)

--- a/src/main/java/com/ft/platform/dropwizard/GoodToGoServlet.java
+++ b/src/main/java/com/ft/platform/dropwizard/GoodToGoServlet.java
@@ -2,6 +2,8 @@ package com.ft.platform.dropwizard;
 
 import static javax.servlet.http.HttpServletResponse.SC_OK;
 import static javax.servlet.http.HttpServletResponse.SC_SERVICE_UNAVAILABLE;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+
 import io.dropwizard.setup.Environment;
 
 import java.io.IOException;
@@ -13,7 +15,8 @@ import javax.servlet.http.HttpServletResponse;
 
 @SuppressWarnings("serial")
 public class GoodToGoServlet extends HttpServlet {
-
+    private static final String ASCII = US_ASCII.name();
+    
 	private final GoodToGoChecker checker;
 	private final Environment environment;
 	private GTGConfig gtgConfig;
@@ -27,7 +30,8 @@ public class GoodToGoServlet extends HttpServlet {
 	@Override
 	protected void doGet(HttpServletRequest req, HttpServletResponse resp)
 			throws ServletException, IOException {
-
+	    
+	    resp.setCharacterEncoding(ASCII);
 		resp.setContentType(gtgConfig.getContentType());
 		resp.setHeader("Cache-Control", "must-revalidate,no-cache,no-store");
 

--- a/src/test/java/com/ft/platform/dropwizard/AdvancedHealthCheckIntegrationTest.java
+++ b/src/test/java/com/ft/platform/dropwizard/AdvancedHealthCheckIntegrationTest.java
@@ -1,10 +1,12 @@
 package com.ft.platform.dropwizard;
 
+import com.codahale.metrics.MetricFilter;
 import com.ft.platform.dropwizard.testsupport.ConfigPathBuilder;
 import com.ft.platform.dropwizard.testsupport.HealthCheckTestConfig;
 import com.ft.platform.dropwizard.testsupport.HealthCheckTestService;
 import com.ft.platform.dropwizard.testsupport.TestAdvancedHealthCheck;
 import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -30,6 +32,11 @@ public class AdvancedHealthCheckIntegrationTest {
     @Before
     public void init() {
         client = app.getConfiguration().buildJerseyClient(app.getEnvironment());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        app.getEnvironment().metrics().removeMatching(MetricFilter.ALL);
     }
 
     @Test

--- a/src/test/java/com/ft/platform/dropwizard/GoodToGoCheckIntegrationTest.java
+++ b/src/test/java/com/ft/platform/dropwizard/GoodToGoCheckIntegrationTest.java
@@ -1,6 +1,8 @@
 package com.ft.platform.dropwizard;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.hamcrest.Matchers.startsWith;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import io.dropwizard.Application;
@@ -12,6 +14,7 @@ import io.dropwizard.setup.Environment;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -19,7 +22,6 @@ import javax.ws.rs.client.Client;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-import org.glassfish.jersey.client.ClientResponse;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,9 +49,7 @@ public class GoodToGoCheckIntegrationTest {
 
 		assertThat(result.getStatus(), is(200));
 		assertThat(result.readEntity(String.class), is("OK"));
-		assertThat(result.getMediaType(), is(MediaType.TEXT_PLAIN_TYPE));
-		assertThat(result.getStringHeaders().getFirst("Cache-Control"),
-				containsString("no-cache"));
+		checkResponseHeaders(result);
 	}
 
 	@Test
@@ -58,8 +58,16 @@ public class GoodToGoCheckIntegrationTest {
 		Response result = getHealthCheckPage();
 
 		assertThat(result.getStatus(), is(503));
+        checkResponseHeaders(result);
 	}
 
+	private void checkResponseHeaders(Response result) {
+        assertThat(result.getMediaType().toString(), startsWith(MediaType.TEXT_PLAIN));
+        assertThat(result.getMediaType().getParameters().get(MediaType.CHARSET_PARAMETER), is(equalToIgnoringCase(StandardCharsets.US_ASCII.name())));
+        assertThat(result.getStringHeaders().getFirst("Cache-Control"),
+                containsString("no-cache"));
+	}
+	
 	private Response getHealthCheckPage() {
 		return client.target(url("/__gtg")).request().get();
 	}


### PR DESCRIPTION
This fixes a class of problems where the incorrect content-type header is included in the GTG response.